### PR TITLE
Make rest of bare git calls use `util.path` and add `"` around where missing.

### DIFF
--- a/src/ViewBranches.ts
+++ b/src/ViewBranches.ts
@@ -59,7 +59,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
         let tree: Flow[] = [];
 
         if (element === undefined) {
-            let list = this.util.execSync(`${this.util.flowPath} config list`);
+            let list = this.util.execSync(`"${this.util.flowPath}" config list`);
 
             if (list.toLowerCase().search("not a gitflow-enabled repo yet") > 0) {
                 let initLink = "Init";
@@ -78,7 +78,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
 
             this.curBranch = this.util.execSync(`"${this.util.path}" rev-parse --abbrev-ref HEAD`).trim();
 
-            let b = this.util.execSync(`${this.util.flowPath} config list`).replace("\r", "").split("\n");
+            let b = this.util.execSync(`"${this.util.flowPath}" config list`).replace("\r", "").split("\n");
             this.branches.master = b[0].split(": ")[1].trim();
             this.branches.develop = b[1].split(": ")[1].trim();
             this.branches.feature = b[2].split(": ")[1].trim();
@@ -314,7 +314,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
                     return;
                 }
                 name = name.replace(/\s/igm, "_");
-                const checked = this.util.execSync(`git check-ref-format --branch ${name}`).trim();
+                const checked = this.util.execSync(`"${this.util.path}" check-ref-format --branch ${name}`).trim();
 
                 if (checked !== name) {
                     vscode.window.showErrorMessage(`Error creating a branch: ${checked}`);
@@ -471,7 +471,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
 
         let config = vscode.workspace.getConfiguration("gitflow");
         let command = config.get("showAllCommands") === true ? " --showcommands " : " ";
-        let cmd = `${this.util.flowPath} ${feature} ${what}${command}${option} ${name} ${base}`;
+        let cmd = `"${this.util.flowPath}" ${feature} ${what}${command}${option} ${name} ${base}`;
         console.log(cmd);
 
         this.util.exec(cmd, progress, (s) => {
@@ -770,7 +770,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
     //#endregion
 
     version(): string {
-        return this.util.execSync(`${this.util.flowPath} version`);
+        return this.util.execSync(`"${this.util.flowPath}" version`);
     }
 
     refresh(): void {

--- a/src/ViewVersions.ts
+++ b/src/ViewVersions.ts
@@ -102,7 +102,7 @@ export class TreeViewVersions implements vscode.TreeDataProvider<Tag> {
         let name = node?.label;
         if (node === undefined) {
             let tags = this.util
-                .execSync("git tag --sort=-v:refname")
+                .execSync(`"${this.util.path}" tag --sort=-v:refname`)
                 .split("\n")
                 .map((el) => el.trim())
                 .filter((el) => el !== "");


### PR DESCRIPTION
.execSync("git…") → .execSync(`"${this.util.path}"…`)

Hopefully finally fixes #21 for reals.