### PR TITLE
feat: add PowerShell support on Windows for UNC paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All basic operations you need to do in a single place.
 - `gitflow.showAllCommands` - This option allows to see in GitFlow output window underground git commands run by git-flow.
 - `gitflow.path` - Allow manually set path for Git Flow executable including `flow`. For instance `/usr/bit/git flow`.
 - `gitflow.autoBumpVersion` - Either it should automatically bump a version in `package.json` file on `feature` or `hotfix` creation, and commit it to git.
+- `gitflow.usePowerShell` - (Windows only) Use PowerShell instead of CMD.exe. Enable this to work with repositories in a workspace under a UNC path (e.g., `\\server\share\repo`). Defaults to `false`.
 
 ## Feature Details
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Disable GitFlow check on this repo"
+                },
+                "gitflow.usePowerShell": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use PowerShell instead of CMD.exe on Windows. Enable this for UNC path (\\\\server\\share) support.",
+                    "scope": "machine-overridable"
                 }
             }
         },

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -3,6 +3,7 @@ import { execSync, exec, spawn, SpawnOptions } from "child_process";
 import { Logger, LogLevels } from "./logger";
 import { Memoize, MemoizeExpiring } from "typescript-memoize";
 import { GitExtension, API as GitAPI } from "./git";
+import { platform } from "os";
 // import { GitBaseExtension, API as GitBaseAPI } from "./lib/git-base";
 
 type CmdResult = {
@@ -14,6 +15,10 @@ type CmdResult = {
 export class Util {
     public path: string = '';
     public flowPath: string = '';
+    private get shell(): string | undefined {
+        const usePowerShell = vscode.workspace.getConfiguration('gitflow').get('usePowerShell', false);
+        return (platform() === 'win32' && usePowerShell) ? 'powershell.exe' : undefined;
+    }
     constructor(public workspaceRoot: string, private logger: Logger, public sb: vscode.StatusBarItem) {
         this.path = vscode.workspace.getConfiguration('git').get('path') || "";
         if (this.path.trim().length === 0) {
@@ -27,6 +32,7 @@ export class Util {
         }
         this.flowPath = vscode.workspace.getConfiguration('gitflow').get('path') || `"${this.path}" flow`;
         this.logger.log("Git found (path)", this.path);
+        
     }
 
     private progress(cmd: string, cb: (s: string) => void) {
@@ -56,6 +62,18 @@ export class Util {
         }
     }
 
+    /**
+     * When using PowerShell, wrap the command with the invocation operator &
+     * so that paths with spaces are properly handled.
+     * Example: "git.exe" version → & "git.exe" version
+     */
+    private prepareCommand(cmd: string): string {
+        if (this.shell === 'powershell.exe') {
+            return `& ${cmd}`;
+        }
+        return cmd;
+    }
+
     @MemoizeExpiring(1000)
     public execSync(cmd: string): string {
         if (this.path.trim().length === 0) {
@@ -63,7 +81,8 @@ export class Util {
         }
         this.sb.text = "$(sync~spin) Git Flow in progress...";
         try {
-            let out = execSync(cmd, { cwd: this.workspaceRoot }).toString();
+            const preparedCmd = this.prepareCommand(cmd);
+            let out = execSync(preparedCmd, { cwd: this.workspaceRoot, shell: this.shell }).toString();
             this.logger.log(out, cmd);
             this.sb.text = "$(list-flat) Git Flow";
             return out;
@@ -81,8 +100,9 @@ export class Util {
             return;
         }
         this.sb.text = "$(sync~spin) Git Flow in progress...";
+        const preparedCmd = this.prepareCommand(cmd);
         exec(
-            cmd, { cwd: this.workspaceRoot, },
+            preparedCmd, { cwd: this.workspaceRoot, shell: this.shell },
             (err, stdout, stderr) => {
                 this.sb.text = "$(list-flat) Git Flow";
                 if (err) {


### PR DESCRIPTION
## Description

This PR adds support for using **PowerShell** instead of `CMD.exe` on Windows, enabling the extension to work with repositories cloned over **UNC paths** (e.g., `\\server\share\repo`).

PowerShell is a more modern shell than CMD.exe with better path handling, native UNC path support, and improved handling of paths with spaces. This change is fully **opt-in** and **backward compatible**.

## Changes

### `package.json`

- Added new configuration setting `gitflow.usePowerShell`:
  - Type: `boolean`
  - Default: `false`
  - Scope: `machine-overridable`
  - Description: "Use PowerShell instead of CMD.exe on Windows. Enable this for UNC path support."

### `src/lib/Util.ts`

- Added `import { platform } from "os"` for platform detection
- Added `shell` getter property that returns `'powershell.exe'` when on Windows and `usePowerShell` is enabled, otherwise `undefined`
- Added `prepareCommand()` private method that wraps commands with PowerShell's invocation operator `&` for proper handling of paths with spaces
- Updated `execSync()` to use prepared command and pass `shell` option
- Updated `exec()` callback to use prepared command and pass `shell` option

## Technical Details

### Shell Detection

```typescript
private get shell(): string | undefined {
    const usePowerShell = vscode.workspace.getConfiguration('gitflow').get('usePowerShell', false);
    return (platform() === 'win32' && usePowerShell) ? 'powershell.exe' : undefined;
}
```

### Command Preparation for PowerShell

When PowerShell is active, commands are wrapped with the `&` invocation operator to handle paths with spaces correctly:

```typescript
private prepareCommand(cmd: string): string {
    if (this.shell === 'powershell.exe') {
        return `& ${cmd}`;
    }
    return cmd;
}
```

## Why PowerShell?

1. **UNC Path Support**: PowerShell natively handles UNC paths (`\\server\share`), which CMD.exe struggles with
2. **Modern Shell**: PowerShell is the recommended shell for Windows automation (replacing CMD.exe)
3. **Better Path Handling**: Built-in support for paths with spaces, special characters, and long paths
4. **Backward Compatible**: The setting defaults to `false`, so existing behavior is unchanged

## Note on UNC Paths and WSL

For users who frequently work with UNC paths on Windows, the **recommended approach** is to use **WSL (Windows Subsystem for Linux)** with the VS Code Remote - WSL extension. WSL provides a full Linux environment with native path handling and better tooling support overall.

However, this PR ensures the extension works in **all scenarios**, including:

- Local Windows paths
- UNC network paths
- Paths with spaces
- Environments where WSL is not available or desired

VS Code itself supports opening workspaces from UNC paths, so this extension should work in those scenarios as well.

## Testing

This change has been tested on the following platforms:

- **Windows 11** (PowerShell enabled and disabled) — all Git Flow commands work correctly
- **Linux (Ubuntu)** — existing functionality remains unaffected

In both cases, the extension behaves as expected with no regressions in the existing functionality.

- [x] Code compiles without errors
- [x] Existing functionality unchanged when `usePowerShell` is `false` (default)
- [x] Tested on Windows with `usePowerShell` enabled
- [x] Tested on Linux (Ubuntu) — no regressions

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested my changes
- [x] My changes are backward compatible
- [x] I have updated the configuration documentation (package.json description)

## Related Issue

Closes #82 