### PR TITLE
fix: properly handle Escape key cancellation in finish and deleteSupport commands

### DIFF
--- a/src/ViewBranches.ts
+++ b/src/ViewBranches.ts
@@ -517,7 +517,7 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
         }
     }
 
-    async _getFinishOptions(what: string): Promise<string[]> {
+    async _getFinishOptions(what: string): Promise<string[] | undefined> {
         return new Promise(async (resolve) => {
             let list: string[] = [];
             switch (what) {
@@ -581,10 +581,10 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
                     break;
             }
             resolve(
-                (await vscode.window.showQuickPick(list, {
+                await vscode.window.showQuickPick(list, {
                     title: "Select delete options",
                     canPickMany: true,
-                })) || []
+                })
             );
         });
     }
@@ -616,6 +616,9 @@ export class TreeViewBranches implements vscode.TreeDataProvider<Flow> {
             title: "Select options",
             canPickMany: true,
         });
+        if (options === undefined) {
+            return;
+        }
         let option = options?.includes("[-f] Force deletion") ? "-D" : "-d";
 
         this.util.execSync(`"${this.util.path}" checkout -d ${this.branches.develop}`);


### PR DESCRIPTION
## Description

This PR fixes an issue where pressing the **Escape** key to cancel the options dialog in the **Finish** and **Delete Support** commands did not abort the operation. Instead, the commands would execute with empty options, potentially performing destructive actions (branch merging or deletion) unintentionally.

The fix ensures that pressing Escape properly cancels the operation, preventing accidental branch modifications when a command is triggered by mistake.

## Changes

### `src/ViewBranches.ts` — `_getFinishOptions()` method

- Updated the return type from `Promise<string[]>` to `Promise<string[] | undefined>` to reflect that the method can return `undefined` when the user cancels.
- Removed the `|| []` fallback that was converting `undefined` (cancellation) into an empty array, which bypassed the existing cancellation guard.

```typescript
// Before
async _getFinishOptions(what: string): Promise<string[]> {
    return new Promise(async (resolve) => {
        // ...
        resolve((await vscode.window.showQuickPick(list, { ... })) || []);
    });
}

// After
async _getFinishOptions(what: string): Promise<string[] | undefined> {
    return new Promise(async (resolve) => {
        // ...
        resolve(await vscode.window.showQuickPick(list, { ... }));
    });
}
```

The existing guard at line 429 (`if (options === undefined) return;`) now properly intercepts the cancellation and aborts the finish operation.

### `src/ViewBranches.ts` — `deleteSupport()` method

- Added a cancellation guard after the `showQuickPick` call to check for `undefined` and return early:

```typescript
let options = await vscode.window.showQuickPick(list, {
    title: "Select options",
    canPickMany: true,
});
if (options === undefined) {
    return;
}
```

This prevents the branch deletion from executing when the user cancels the dialog with Escape.

## Additional Note: `deleteTag` in `src/ViewVersions.ts`

During the investigation, a similar pattern was identified in the `deleteTag()` method (`ViewVersions.ts`, line 88–91), which uses `|| []` after a `showQuickPick` with `canPickMany: true`.

**This case was not modified** because it functions correctly in practice: when the user presses Escape, `remotes` becomes `[]`, and neither `.includes("Delete Remote")` nor `.includes("Delete local")` evaluates to `true`, so no deletion occurs. The behavior is correct but inconsistent with the rest of the codebase. It is recommended to address this in a future cleanup for consistency.

## Why This Fix Matters

1. **Prevents accidental data loss**: The `finish` command merges and deletes branches, and `deleteSupport` deletes branches. Executing these operations unintentionally can result in lost work.
2. **Consistent UX**: Other commands like `delete` and `rebase` already handle Escape cancellation correctly. This fix brings `finish` and `deleteSupport` in line with the expected behavior.
3. **No breaking changes**: The fix only affects the cancellation path. Normal operation (selecting options and confirming) remains unchanged.

## Testing

This change has been tested on the following scenarios:

- **Finish command** — Pressing Escape on the options dialog correctly cancels the operation for feature, release, hotfix, and bugfix branches.
- **Delete Support command** — Pressing Escape on the options dialog correctly cancels the deletion.
- **Normal operation** — Selecting options and pressing Enter still executes the commands as expected.

- [x] Code compiles without errors
- [x] Escape cancellation works for finish command
- [x] Escape cancellation works for deleteSupport command
- [x] Normal operation (selecting options and confirming) unchanged
- [x] No regressions in other commands

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested my changes
- [x] My changes are backward compatible
- [x] I have identified and documented related issues for future cleanup

## Related Issue

Closes #85 